### PR TITLE
Fixing `mcmc` module imports

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -15,3 +15,7 @@ dependencies:
   - ipywidgets
   - xarray
   - dask
+  - arviz
+  - numexpr
+  - tqdm
+  - h5py

--- a/molsim/__init__.py
+++ b/molsim/__init__.py
@@ -2,7 +2,7 @@
 A program for simulating observations of molecular rotational spectra
 '''
 __author__ = 'Brett A. McGuire'
-__version__ = '0.1.0'
+__version__ = '0.1.2'
 __email__ = 'brettmc@mit.edu'
 __status__ = 'Development'
 
@@ -16,3 +16,4 @@ from . import functions
 from . import utils
 from . import plotting
 from . import analysis
+from . import mcmc

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ VERSION = '0.1.1'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'astropy', 'numpy', 'scipy', 'emcee', 'matplotlib', 'tabulate', 'ruamel.yaml', 'lmfit'
+    'astropy', 'numpy', 'scipy', 'emcee', 'matplotlib', 'tabulate', 'ruamel.yaml', 'lmfit', 'loguru', 'tqdm'
 ]
 
 # What packages are optional?


### PR DESCRIPTION
This commit adds the `mcmc` submodule into the rest of the package, as
well as resolves a bunch of missing packages from `conda.yml` and
`setup.py`. This addresses issue #40 and a bit more.