### PR TITLE
Fix incorrect indexing in print_lines()

### DIFF
--- a/molsim/classes.py
+++ b/molsim/classes.py
@@ -1433,12 +1433,12 @@ class Simulation(object):
 			uls = self.ul
 			
 		#for getting from catalogs	
-		l_idxs = [find_nearest(self.mol.catalog.frequency,x) for x in lls]
-		u_idxs = [find_nearest(self.mol.catalog.frequency,x) for x in uls]
+		l_idxs = np.searchsorted(self.mol.catalog.frequency, lls)
+		u_idxs = np.searchsorted(self.mol.catalog.frequency, uls)
 		
 		#for getting from the simulation spectrum
-		sim_l_idxs = [find_nearest(self.spectrum.frequency,x) for x in lls]
-		sim_u_idxs = [find_nearest(self.spectrum.frequency,x) for x in uls]
+		sim_l_idxs = np.searchsorted(self.spectrum.frequency, lls)
+		sim_u_idxs = np.searchsorted(self.spectrum.frequency, uls)
 		
 		print_freqs = []
 		print_ints = []
@@ -1450,9 +1450,8 @@ class Simulation(object):
 		print_sijmus = []
 		
 		for x,y in zip(l_idxs,u_idxs):
-			print_freqs.append(self.mol.catalog.frequency[x:y]) if x != y else print_freqs.append([self.mol.catalog.frequency[x]])
-			if x == y:
-				i = x
+			print_freqs.append(self.mol.catalog.frequency[x:y])
+			for i in range(x,y):
 				qn_us = []
 				for qn_u in [self.mol.catalog.qn1up[i], self.mol.catalog.qn2up[i], self.mol.catalog.qn3up[i], self.mol.catalog.qn4up[i], self.mol.catalog.qn5up[i], self.mol.catalog.qn6up[i], self.mol.catalog.qn7up[i], self.mol.catalog.qn8up[i]]:
 					if qn_u is not None:
@@ -1463,28 +1462,15 @@ class Simulation(object):
 						qn_ls.append(qn_l)
 				qn_u_str = _make_fmted_qnstr(qn_us)
 				qn_l_str = _make_fmted_qnstr(qn_ls)
-				print_qns.append(qn_u_str + ' -> ' + qn_l_str)	
-			else:
-				for i in range(x,y):
-					qn_us = []
-					for qn_u in [self.mol.catalog.qn1up[i], self.mol.catalog.qn2up[i], self.mol.catalog.qn3up[i], self.mol.catalog.qn4up[i], self.mol.catalog.qn5up[i], self.mol.catalog.qn6up[i], self.mol.catalog.qn7up[i], self.mol.catalog.qn8up[i]]:
-						if qn_u is not None:
-							qn_us.append(qn_u)
-					qn_ls = []
-					for qn_l in [self.mol.catalog.qn1low[i], self.mol.catalog.qn2low[i], self.mol.catalog.qn3low[i], self.mol.catalog.qn4low[i], self.mol.catalog.qn5low[i], self.mol.catalog.qn6low[i], self.mol.catalog.qn7low[i], self.mol.catalog.qn8low[i], ]:
-						if qn_l is not None:
-							qn_ls.append(qn_l)
-					qn_u_str = _make_fmted_qnstr(qn_us)
-					qn_l_str = _make_fmted_qnstr(qn_ls)
-					print_qns.append(qn_u_str + ' -> ' + qn_l_str)
-			print_eups.append(self.mol.catalog.eup[x:y]) if x != y else print_eups.append([self.mol.catalog.eup[x]])
-			print_gus.append(self.mol.catalog.gup[x:y]) if x != y else print_gus.append([self.mol.catalog.gup[x]])
-			print_gls.append(self.mol.catalog.glow[x:y]) if x != y else print_gls.append([self.mol.catalog.glow[x]])
-			print_aijs.append(np.log10(self.mol.catalog.aij[x:y])) if x != y else print_aijs.append(np.log10([self.mol.catalog.aij[x]]))
-			print_sijmus.append(self.mol.catalog.sijmu[x:y]) if x != y else	print_sijmus.append([self.mol.catalog.sijmu[x]])		 				 
+				print_qns.append(qn_u_str + ' -> ' + qn_l_str)
+			print_eups.append(self.mol.catalog.eup[x:y])
+			print_gus.append(self.mol.catalog.gup[x:y])
+			print_gls.append(self.mol.catalog.glow[x:y])
+			print_aijs.append(np.log10(self.mol.catalog.aij[x:y]))
+			print_sijmus.append(self.mol.catalog.sijmu[x:y])
 				
 		for x,y in zip(sim_l_idxs,sim_u_idxs):	
-			print_ints.append(self.spectrum.Tb[x:y]) if x != y else print_ints.append([self.spectrum.Tb[x]])
+			print_ints.append(self.spectrum.Tb[x:y])
 		
 		print_freqs = np.array([item for sublist in print_freqs for item in sublist])
 		print_ints = np.array([item for sublist in print_ints for item in sublist])


### PR DESCRIPTION
When `ll` or `ul` is close to a line that is not simulated, incorrect index ranges would be found.
For example, when `self.mol.catalog.frequency = [1000, 2000, 3000]`, `lls = [1300]` and `uls = [2700]`, `self.spectrum.frequency = [2000]`. In the original version, `l_idxs = [0]`, `u_idxs = [2]` whereas `sim_l_idxs = [0]`, `sim_u_idxs = [0]`. It resulted in that two frequencies were appended to the list while only one Tb was appended, which caused inconsistent printed table with shifted rows. 
In this commit, `l_idxs` always point to the first frequency in ranges and `u_idxs` points to the first frequency that is out of ranges, i.e., in the example, `l_idxs = [1]`, `u_idxs = [2]` and `sim_l_idxs = [0]`, `sim_u_idxs = [1]`. 
