### PR TITLE
Revise find_limits algorithm and fix sum_spectra for non-uniform array

### DIFF
--- a/molsim/functions.py
+++ b/molsim/functions.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 
 
-def sum_spectra(sims,thin=True,Tex=None,Tbg=None,res=None,noise=None,override_freqs=None,planck=False,name='sum'):
+def sum_spectra(sims,thin=True,Tex=None,Tbg=None,res=None,noise=None,override_freqs=None,planck=False,name='sum',tau_threshold=1000.,spacing_tolerance=None):
 
 	'''
 	Adds all the spectra in the simulations list and returns a spectrum object.  By default,
@@ -26,10 +26,18 @@ def sum_spectra(sims,thin=True,Tex=None,Tbg=None,res=None,noise=None,override_fr
 	
 	'''
 
+	if any([x.use_obs for x in sims]):
+		if res is None and override_freqs is None:
+			raise RuntimeError("Resolution cannot be determined since one or more spectra enabled `use_obs`. Please specify `res` or `override_freqs` to prevent this error.")
 		
 	#first figure out what the resolution needs to be if it wasn't set
 	if res is None:
 		res = min([x.res for x in sims])
+
+	#then figure out the spacing tolerance needed if it wasn't set
+	if spacing_tolerance is None:
+		# 4 in the spacing_tolerance is a magic number that can deal with doubly-repeated frequencies per simulated spectrum
+		spacing_tolerance = 4*len(sims)
 		
 	
 	#check if override_freqs has been specified, and if so, use that.
@@ -43,7 +51,7 @@ def sum_spectra(sims,thin=True,Tex=None,Tbg=None,res=None,noise=None,override_fr
 		#eliminate all duplicate entries
 		total_freq = np.array(list(set(total_freq)))
 		total_freq.sort()
-		lls,uls = find_limits(total_freq,spacing_tolerance=2,padding=0)
+		lls,uls = find_limits(total_freq,spacing_tolerance=spacing_tolerance,padding=0)
 		
 		#now make a resampled array
 		freq_arr = np.concatenate([np.arange(ll,ul,res) for ll,ul in zip(lls,uls)])	

--- a/molsim/utils.py
+++ b/molsim/utils.py
@@ -165,19 +165,24 @@ def find_limits(freq_arr,spacing_tolerance=100,padding=0):
 	# 	print('The input array has no data.')
 	# 	return
 
-	#first, calculate the most common data point spacing as the mode of the spacings
-	#this won't be perfect if the data aren't uniformly sampled
-	#get the differences
-	diffs = np.diff(freq_arr)
-	spacing = stats.mode(diffs)[0][0]
-	
-	gaps = np.where(abs(diffs) > spacing*spacing_tolerance)
-	
-	ll = np.concatenate((np.array([freq_arr[0]]),freq_arr[gaps[0][:]+1]))
-	ul = np.concatenate((freq_arr[gaps[0][:]],np.array([freq_arr[-1]])))
-	
-	ll -= padding*ll/ckm
-	ul += padding*ul/ckm
+	# this algorithm compares each gap against the average spacing of spacing_tolerance nearby points
+	# if the gap is larger than spacing_tolerance * average spacing in both directions, it is considered as the actual gap
+	# simplifying it gives the following expressions
+
+	t = spacing_tolerance
+	center = freq_arr[t+1:-t] - freq_arr[t:-t-1]
+	left = freq_arr[t:-t-1] - freq_arr[:-2*t-1]
+	right = freq_arr[2*t+1:] - freq_arr[t+1:-t]
+
+	gaps = np.concatenate(([-1], np.where(np.logical_and(center > left, center > right))[0] + t, [-1]))
+
+	ll = freq_arr[gaps[:-1]+1]
+	ul = freq_arr[gaps[1:]]
+
+	# the original expressions require 1 addition, 1 multiplication and 1 division operations per element, i.e. 3N operations, plus memory allocation and deallocation of temporary array
+	# the following use 1 multiplication per element plus 1 addition and 1 division, i.e. N+2 operations, without allocating temporary array
+	ll *= 1 - padding/ckm
+	ul *= 1 + padding/ckm
 	
 	return ll,ul
 	


### PR DESCRIPTION
In `find_limits()`, when use the statistical mode as `spacing` as in the original version, incorrect determination of gaps can happen if the frequencies are non-uniformly spaced, especially when the contrast is large, e.g. |.......|.|......|.|.....|...|.......||.......|. An example of non-uniform spectra is the one generated by `sum_spectra()` when uniformly spaced simulated spectra are overlaid on each other (`total_freq`). As such `sum_spectra()` can break down when some certain combinations of velocities are inputted to `Simulation`.

The revised `find_limits()` in this commit uses the average spacing of `spacing_tolerance` nearby points as `spacing`. Then it compares each gap against the corresponding `spacing` in both directions and the gaps larger than `spacing_tolerance * spacing` are considered as the actual gaps. It resolves #29.

Furthermore, with the revised `find_limits()`, the parameter `spacing_tolerance` is also introduced to `sum_spectra()` for customization if needed. For example, for spectrum with triply-repeated frequencies, a number of `6 * len(sims)` is required. Since it is very rare, the default is set to `4 * len(sims)` for spectrum with doubly-repeated frequencies (e.g. PRIMOS spectrum).

This commit also add a trap when one or more simulations that used the `use_obs=True` option are passed into `sum_spectra()` without specifying `res`, which is relevant to #43.
