### PR TITLE
Print_lines() fix

### DIFF
--- a/molsim/classes.py
+++ b/molsim/classes.py
@@ -1207,7 +1207,6 @@ class Simulation(object):
 				self.ul = self.ul.tolist()
 			else:
 				self.ul = [self.ul]
-		#SAMER
 		mask = _trim_arr(self.mol.catalog.frequency - self.source.velocity*self.mol.catalog.frequency/ckm,self.ll,self.ul,return_mask=True)
 		self.spectrum.frequency = self.mol.catalog.frequency[mask]
 		self.spectrum.freq0 = np.copy(self.spectrum.frequency)

--- a/molsim/classes.py
+++ b/molsim/classes.py
@@ -1393,7 +1393,7 @@ class Simulation(object):
 		
 		return
 				
-	def print_lines(self,ll=None,ul=None,threshold=0.,use_profile=False,dV=None,vlsr=None,file_out=None,latex_out=False,txt_out=False,eup_threshold=0.):
+	def print_lines(self,ll=None,ul=None,threshold=None,use_profile=False,dV=None,vlsr=None,file_out=None,latex_out=False,txt_out=False,eup_threshold=None):
 	
 		'''
 		Prints all the lines within the simulation, optionally with constraints or output to a file.


### PR DESCRIPTION
Doppler shifted the catalog frequencies for every Simulation object which fixes the discrepancy in the intensities for print_lines() and adjusted a (-) sign. Also updated how the threshold masks are created and combined in print_lines()