### PR TITLE
Fix mcmc cal noise and indexing

### DIFF
--- a/molsim/mcmc/compute.py
+++ b/molsim/mcmc/compute.py
@@ -39,23 +39,23 @@ def calc_noise_std(intensity, threshold=3.5) -> Tuple[np.ndarray, np.ndarray]:
     dummy_std = np.nanstd(dummy_ints)
 
     # repeats 3 times to make sure to avoid any interloping lines
-    for chan in np.where(dummy_ints < (-dummy_std*threshold))[0]:
+    for chan in np.where(dummy_ints-dummy_mean < (-dummy_std*threshold))[0]:
         noise[chan-10:chan+10] = np.nan
-    for chan in np.where(dummy_ints > (dummy_std*threshold))[0]:
-        noise[chan-10:chan+10] = np.nan
-    noise_mean = np.nanmean(noise)
-    noise_std = np.nanstd(np.real(noise))
-
-    for chan in np.where(dummy_ints < (-noise_std*threshold))[0]:
-        noise[chan-10:chan+10] = np.nan
-    for chan in np.where(dummy_ints > (noise_std*threshold))[0]:
+    for chan in np.where(dummy_ints-dummy_mean > (dummy_std*threshold))[0]:
         noise[chan-10:chan+10] = np.nan
     noise_mean = np.nanmean(noise)
     noise_std = np.nanstd(np.real(noise))
 
-    for chan in np.where(dummy_ints < (-dummy_std*threshold))[0]:
+    for chan in np.where(dummy_ints-noise_mean < (-noise_std*threshold))[0]:
         noise[chan-10:chan+10] = np.nan
-    for chan in np.where(dummy_ints > (dummy_std*threshold))[0]:
+    for chan in np.where(dummy_ints-noise_mean > (noise_std*threshold))[0]:
+        noise[chan-10:chan+10] = np.nan
+    noise_mean = np.nanmean(noise)
+    noise_std = np.nanstd(np.real(noise))
+
+    for chan in np.where(dummy_ints-noise_mean < (-noise_std*threshold))[0]:
+        noise[chan-10:chan+10] = np.nan
+    for chan in np.where(dummy_ints-noise_mean > (noise_std*threshold))[0]:
         noise[chan-10:chan+10] = np.nan
     noise_mean = np.nanmean(noise)
     noise_std = np.nanstd(np.real(noise))

--- a/molsim/mcmc/models.py
+++ b/molsim/mcmc/models.py
@@ -425,7 +425,7 @@ class MultiComponent(SingleComponent):
     def _get_component_parameters(
         self, parameters: np.ndarray, component: int
     ) -> np.ndarray:
-        subparams = parameters[component:-2:4]
+        subparams = parameters[component:-2:len(self.components)]
         # tack on the excitation temperature and linewidth, which are global
         subparams = np.append(subparams, [parameters[-2], parameters[-1]])
         return subparams


### PR DESCRIPTION
Correct `calc_noise_std()` to be able to find deviation around baseline which might not be at zero, also fix incorrect indexing in `MultiComponent()`.