### PR TITLE
Implement plot_html()

### DIFF
--- a/ipython_quickstart.py
+++ b/ipython_quickstart.py
@@ -10,7 +10,7 @@ from molsim.classes import Workspace, Catalog, Transition, Level, Molecule, Part
 from molsim.stats import get_rms
 from molsim.utils import _trim_arr, find_nearest, _make_gauss, _apply_vlsr, find_limits, find_peaks, _get_res, _find_nans, _find_limit_idx, generate_spcat_qrots, process_mcmc_json
 from molsim.functions import sum_spectra, velocity_stack, matched_filter, convert_spcat, resample_obs
-from molsim.plotting import plot_mf, plot_stack, plot_sim
+from molsim.plotting import plot_mf, plot_stack, plot_sim, plot_html
 from molsim.analysis import set_upper_limit
 from datetime import date
 import matplotlib.pyplot as plt

--- a/molsim/plotting.py
+++ b/molsim/plotting.py
@@ -552,7 +552,7 @@ def plot_html(params={}):
 		fig.add_trace(go.Scatter(x=spectrum.freq_profile, y=spectrum.int_profile, line_shape=drawstyle, line=dict(width=linewidth, color=color), name=label))
 	
 	#save it
-	open(file_out, 'w').write(fig.to_html(include_mathjax='cdn'))
+	open(file_out, 'w').write(fig.to_html(include_mathjax='cdn', include_plotlyjs='cdn'))
 	
 	return
 	


### PR DESCRIPTION

Plots spectra using `plotly` package and output to a portable html file, which provides an interactive user interface. Input params are similar to ` plot_sim()`, other than that `sim` is not a positional argument but specified in params like `obs`.