### PR TITLE
Fix ResolvePackageNotFound error during build

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -1,7 +1,6 @@
 name: molsim
 channels:
   - defaults
-  - conda-forge
 dependencies:
   - numpy
   - scipy
@@ -21,6 +20,7 @@ dependencies:
   - tqdm
   - h5py
   - tabulate
-  - emcee
   - loguru
-  - lmfit
+  - pip:
+    - emcee
+    - lmfit

--- a/conda.yml
+++ b/conda.yml
@@ -1,6 +1,7 @@
 name: molsim
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - numpy
   - scipy


### PR DESCRIPTION
When running the `molsim-CI` workflow, issues arose during solving environment: 
```
Solving environment: ...working... failed

ResolvePackageNotFound: 
 - emcee
 - lmfit

Error: Process completed with exit code 1.
```

It is because the two packages `emcee` and `lmfit` are not included in the `default` conda channel. Since they are both in the `conda-forge` channel, adding the `conda-forge` channel resolves the issue. Noted, since `conda-forge` has lots of recipes, the solving environment step will take a longer time.
