### PR TITLE
Create testing env and pin python version to 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,25 +19,29 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.1
+      - name: Create and activate conda environment for testing
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7.9
+          activate-environment: molsim-testing
+          python-version: 3.7
       - name: Install dependencies with anaconda
         run: |
-          $CONDA/bin/conda env update -f conda.yml --name base
-          $CONDA/bin/conda install flake8 pytest
-          $CONDA/bin/pip install --upgrade pip
+          conda env update -f conda.yml --name molsim-testing
+          conda install flake8 pytest
+          pip install --upgrade pip
       - name: Install molsim into environment
         run: |
-          $CONDA/bin/pip install -e .[dev]
+          pip install -e .[dev]
       - name: Run CI actions
         run: |
-          # $CONDA/bin/flake8
-          $CONDA/bin/pytest
+          # flake8
+          pytest


### PR DESCRIPTION
# Background
Commit 8a97205 removes python version requirement from conda.yml causing CI workflows to fail.

# Root cause
Removing python version requirement lead to anaconda using the latest python available, which is 3.10. At version 3.10, a newer Numpy version is supported and used. The newer version of Numpy deprecated `np.float`, which is an alias of the built-in `float` function. `np.float` is used in molsim/classes.py and therefore causes the test to break.

# Changes
A conda environment with python version 3.7 is created and used in CI workflows, which limits an older Numpy version where `np.float` is not deprecated.

# Next step
The use of `np.float` in molsim should be deprecated and replaced with the appropriate function. The python version in CI workflows needs to be bumped afterward.