### PR TITLE
Implement RADEX non-LTE radiative transfer algorithm

### DIFF
--- a/molsim/classes.py
+++ b/molsim/classes.py
@@ -1019,8 +1019,7 @@ class Continuum(object):
 		densities [Jy/sr] at those frequencies.
 		'''
 		
-		if self.type == 'thermal':
-			return 2*h*(freq*1E6)**3 / (cm**2 * np.exp(h*freq*1E6/(k*self.params)))*1E26		
+		return 2*h*(freq*1E6)**3 / (cm**2 * (np.exp(h*freq*1E6/(k*self.Tbg(freq)))-1))*1E26		
 
 class Source(object):
 

--- a/molsim/mcmc/preprocess.py
+++ b/molsim/mcmc/preprocess.py
@@ -173,6 +173,7 @@ def extract_chunks(
                 inband_data, data, rbf_params, noise_params, verbose
             )
             last_freq = inband_data[1]
+            chunks.append(chunk)
         else:
             pass
     logger.info(f"Created {len(chunks)} chunks.")

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -732,14 +732,14 @@ class NonLTESource:
 
 @dataclass
 class NonLTESimulation:
-    source: Union[NonLTESource, List[NonLTESource]]         # List of NonLTESource objects associated with this simulation
+    source: List[NonLTESource]                              # List of NonLTESource objects associated with this simulation
     size: float                                             # source size
 
     continuum: Continuum = field(default_factory=Continuum) # Continuum object
     aperture: Optional[float] = None                        # aperture size for spectrum extraction [arcsec]
 
-    ll: Union[float, List[float]] = -np.Infinity            # lower limits [MHz]
-    ul: Union[float, List[float]] = np.Infinity             # upper limits [MHz]
+    ll: List[float] = -np.Infinity                          # lower limits [MHz]
+    ul: List[float] = np.Infinity                           # upper limits [MHz]
     sim_width: float = 10.0                                 # FWHMs to simulate +/- line center
     res: float = 0.01                                       # resolution if simulating line profiles [MHz]
     units: str = 'K'                                        # units for the simulation; accepts 'K', 'mK', 'Jy/beam'
@@ -747,6 +747,7 @@ class NonLTESimulation:
     observation: Optional[Observation] = None               # Observation object associated with this simulation
 
     spectrum: Spectrum = field(default_factory=Spectrum)    # Spectrum object associated with this simulation
+    beam_dilution: float = field(init=False)
 
     def __post_init__(self: NonLTESimulation):
         # cast to list if needed
@@ -760,8 +761,6 @@ class NonLTESimulation:
             self.ul = [self.ul]
 
         # merge and sort ll ul intervals
-        assert isinstance(self.ll, Iterable)
-        assert isinstance(self.ul, Iterable)
         self.ll, self.ul = map(lambda x: list(x), zip(*_merge_intervals(zip(self.ll, self.ul))))
 
         # check if observation is provided
@@ -794,10 +793,6 @@ class NonLTESimulation:
         return tau, Iv
 
     def _update(self: NonLTESimulation):
-        assert isinstance(self.source, Iterable)
-        assert isinstance(self.ll, Iterable)
-        assert isinstance(self.ul, Iterable)
-
         # first, set up the frequency grid
         if self.use_obs:
             assert isinstance(self.observation, Observation)

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -460,9 +460,15 @@ class NonLTESource:
     ccrit: float = 1e-6
     Tex_relaxation_coefficient: float = 0.5
     xpop_relaxation_coefficient: float = 0.3
+    use_random: bool = False
+    rng: np.random.Generator = None
 
     _tau: np.ndarray[float] = field(init=False, repr=False)
     _Tex: np.ndarray[float] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        if self.use_random and self.rng is None:
+            object.__setattr__(self, 'rng', np.random.default_rng())
 
     @property
     def Tkin(self: NonLTESource) -> float:
@@ -738,7 +744,11 @@ class NonLTESource:
 
             if niter != 0:
                 self.relaxation(self.Tex_relaxation_coefficient, Tex, Tex_old)
-                self.relaxation(self.xpop_relaxation_coefficient, xpop, xpop_old)
+                if self.use_random:
+                    xpop_relaxation_coefficient = self.rng.uniform(0.0, self.xpop_relaxation_coefficient)
+                else:
+                    xpop_relaxation_coefficient = self.xpop_relaxation_coefficient
+                self.relaxation(xpop_relaxation_coefficient, xpop, xpop_old)
 
             if converged:
                 break

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -939,6 +939,7 @@ class NonLTESimulation:
         intensity += continuum_Ibg_cgs * np.expm1(-cumulative_tau)
 
         # fourth, correct for beam dilution for gaussian beam or uniform aperture
+        beam_dilution = None
         if self.observation is not None:
             if self.observation.observatory.sd is True:
                 intensity, beam_dilution = _apply_beam(
@@ -961,5 +962,6 @@ class NonLTESimulation:
 
         self.spectrum.freq_profile = frequency
         self.spectrum.int_profile = intensity
-        self.beam_dilution = beam_dilution
+        if beam_dilution is not None:
+            self.beam_dilution = beam_dilution
         self.spectrum.Tbg = _rayleigh_jeans_temperature(continuum_Ibg_cgs, frequency)

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -225,9 +225,12 @@ class CollisionalTransitions:
         fields['num_transitions'] = int(file_in.readline().split(maxsplit=1)[0])
         _ = file_in.readline()
         fields['num_temperatures'] = int(file_in.readline().split(maxsplit=1)[0])
+        fields['num_temperatures'] += 1
 
         _ = file_in.readline()
         fields['temperatures'] = [*map(float, file_in.readline().split())]
+        fields['temperatures'].insert(0, 0.0)
+        fields['temperatures'] = np.array(fields['temperatures'])
 
         _ = file_in.readline()
         fields['transition_numbers'] = list()
@@ -240,6 +243,7 @@ class CollisionalTransitions:
             fields['upper_level_numbers'].append(int(cords[1]))
             fields['lower_level_numbers'].append(int(cords[2]))
             fields['rate_coefficients'].append([*map(float, cords[3:])])
+            fields['rate_coefficients'][-1].insert(0, 0.0)
         fields['transition_numbers'] = np.array(fields['transition_numbers'])
         fields['upper_level_numbers'] = np.array(fields['upper_level_numbers'])
         fields['lower_level_numbers'] = np.array(fields['lower_level_numbers'])

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -36,18 +36,21 @@ def _merge_intervals(intervals: Iterable[Tuple[float, float]]) -> List[Tuple[flo
     return merged
 
 
-def _intersect_intervals(a, b):
-    intersected = []
-    i = j = 0
-    while i < len(a) and j < len(b):
-        lo = max(a[i][0], b[j][0])
-        hi = min(a[i][1], b[j][1])
+def _intersect_intervals(list_a: Iterable[Tuple[float, float]], list_b: Iterable[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    intersected: List[Tuple[float, float]] = []
+    it_a = iter(list_a)
+    it_b = iter(list_b)
+    a = next(it_a, None)
+    b = next(it_b, None)
+    while a is not None and b is not None:
+        lo = max(a[0], b[0])
+        hi = min(a[1], b[1])
         if lo <= hi:
-            intersected.append([lo, hi])
-        if a[i][1] < b[j][1]:
-            i += 1
+            intersected.append((lo, hi))
+        if a[1] < b[1]:
+            a = next(it_a, None)
         else:
-            j += 1
+            b = next(it_b, None)
     return intersected
 
 

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -406,6 +406,19 @@ class NonLTESourceMutableParameters:
     column: float
     dV: float
 
+    _mutated: bool = field(init=False, repr=False)
+
+    def __setattr__(self: NonLTESourceMutableParameters, name: str, value: Any):
+        if name != '_mutated' and (not hasattr(self, name) or getattr(self, name) != value):
+            self._mutated = True
+        object.__setattr__(self, name, value)
+
+    def is_mutated(self: NonLTESourceMutableParameters, reset: bool = True) -> bool:
+        ret = self._mutated
+        if reset:
+            self._mutated = False
+        return ret
+
 
 @dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=True)
 class NonLTESource:

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from ..constants import cm, ckm, h, k
+from .interface import run as radex_run, read as radex_read
+
+
+def _planck(T, freq):
+    f = freq * 1e6
+    return (1e26 * 2 * h / cm**2) * f**3 / np.expm1((h * f) / (k * T))
+
+
+@dataclass
+class NonLTESource:
+    """Class for keeping non-LTE source properties"""
+
+    velocity: float = 0.0   # lsr velocity [km/s]
+    dV: float = 3.0         # FWHM [km/s]
+    column: float = 1e10    # column density [cm^-2]
+    Tbg: float = 2.725      # background temperature [K]
+    Tkin: float = 30.0      # kinetic temperature [K]
+    # density of the collision partner as a dictionary [cm^-3]
+    collision_density: dict = field(default_factory=lambda: {'H2': 1e4})
+    # LAMDA collisional data file
+    collision_file: str = 'hco+.dat'
+    # temperary file that store output from RADEX
+    radex_output: str = '/tmp/radex.out'
+
+    def __post_init__(self):
+        # run RADEX simulation to obtain excitation temperatures and optical depths
+        outfile = radex_run(
+            molfile=self.collision_file,
+            outfile=self.radex_output,
+            f_low=3.0,  # 3 GHz is the minimum since RADEX cannot display wavelength > 1e5 um
+            f_high=1e5, # 1e5 GHz is the maximum since RADEX cannot display frequency > 1e5 GHz
+            T_k=self.Tkin,
+            n_c=self.collision_density,
+            T_bg=self.Tbg,
+            N=self.column,
+            dV=self.dV
+        )
+        parameters_keys, parameters_values, grid = radex_read(outfile)
+        # RADEX precision is low, choose smartly between wavelength and frequency
+        # TODO: use collision_file to correct the frequency
+        self.frequency = np.array([cm / g['WAVEL'] if g['WAVEL'] > g['FREQ'] else g['FREQ'] * 1e3 for g in grid])
+        self.frequency *= 1 - self.velocity / ckm
+        # T_EX and TAU may be insensitive to small changes in input
+        # reimplementing RADEX is required to correct the problem
+        self.Tex = np.array([g['T_EX'] for g in grid])
+        self.tau = np.array([g['TAU'] for g in grid])
+
+    def get_tau_Iv(self, freq, sim_width = 10.0):
+        tau = np.zeros_like(freq)
+        Iv = np.zeros_like(freq)
+
+        for freq_, Tex_, tau_ in zip(self.frequency, self.Tex, self.tau):
+            dfreq = self.dV / ckm * freq_
+            two_sigma_sq = dfreq**2 / (4 * np.log(2))
+            lo = np.searchsorted(freq, freq_ - sim_width * dfreq, side='left')
+            hi = np.searchsorted(freq, freq_ + sim_width * dfreq, side='right')
+            f = freq[lo:hi]
+            t = tau_ * np.exp(-(f - freq_)**2 / two_sigma_sq)
+            tau[lo:hi] += t
+            Iv[lo:hi] += _planck(Tex_, f) * t  # TODO: double-check this expression
+
+        mask = tau > 0.0
+        Iv[mask] *= -np.expm1(-tau[mask]) / tau[mask]
+        return tau, Iv

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -935,7 +935,8 @@ class NonLTESimulation:
             cumulative_tau += tau
 
         # third, compute the contribution from background continuum source, and subtract the continuum
-        intensity += self.continuum.Ibg(frequency) * np.expm1(-cumulative_tau)
+        continuum_Ibg_cgs = self.continuum.Ibg(frequency)
+        intensity += continuum_Ibg_cgs * np.expm1(-cumulative_tau)
 
         # fourth, correct for beam dilution for gaussian beam or uniform aperture
         if self.observation is not None:
@@ -961,3 +962,4 @@ class NonLTESimulation:
         self.spectrum.freq_profile = frequency
         self.spectrum.int_profile = intensity
         self.beam_dilution = beam_dilution
+        self.spectrum.Tbg = _rayleigh_jeans_temperature(continuum_Ibg_cgs, frequency)

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -405,11 +405,13 @@ class NonLTESourceMutableParameters:
     escape_probability: EscapeProbability
     column: float
     dV: float
+    velocity: float
 
     _mutated: bool = field(init=False, repr=False)
 
     def __setattr__(self: NonLTESourceMutableParameters, name: str, value: Any):
-        if name != '_mutated' and (not hasattr(self, name) or getattr(self, name) != value):
+        untracked = ['_mutated', 'velocity']
+        if name not in untracked and (not hasattr(self, name) or getattr(self, name) != value):
             self._mutated = True
         object.__setattr__(self, name, value)
 
@@ -430,7 +432,7 @@ class NonLTESource:
 
     @property
     def frequency(self: NonLTESource) -> np.ndarray[float]:
-        return self.molecule.radiative_transitions.frequencies
+        return self.molecule.radiative_transitions.frequencies * (1.0 - self.velocity / ckm)
 
     @property
     def tau(self: NonLTESource) -> np.ndarray[float]:

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -767,7 +767,7 @@ class NonLTESource:
                 if isinstance(background, Continuum):
                     Tex_old = background.Tbg(radiative_transitions.frequencies)
                 else:
-                    Tex_old = np.full(num_transitions, background)
+                    Tex_old = np.full(num_transitions, background, dtype=float)
             else:
                 Tex_old, Tex = Tex, Tex_old
             self.set_excitation_temperature(xpop, Tex_old, Tex)

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -116,6 +116,19 @@ class RadiativeTransitions:
     ediff: np.ndarray[float]
     gratio: np.ndarray[float]
 
+    def __post_init__(self: RadiativeTransitions):
+        isort = np.argsort(self.frequencies)
+        object.__setattr__(self, 'transition_numbers', self.transition_numbers[isort])
+        object.__setattr__(self, 'upper_level_numbers', self.upper_level_numbers[isort])
+        object.__setattr__(self, 'lower_level_numbers', self.lower_level_numbers[isort])
+        object.__setattr__(self, 'spontaneous_decay_rates', self.spontaneous_decay_rates[isort])
+        object.__setattr__(self, 'frequencies', self.frequencies[isort])
+        object.__setattr__(self, 'upper_level_energies', self.upper_level_energies[isort])
+        object.__setattr__(self, 'upper_level_indices', self.upper_level_indices[isort])
+        object.__setattr__(self, 'lower_level_indices', self.lower_level_indices[isort])
+        object.__setattr__(self, 'ediff', self.ediff[isort])
+        object.__setattr__(self, 'gratio', self.gratio[isort])
+
     def __repr__(self:RadiativeTransitions) -> str:
         return f'<RadiativeTransitions object with {len(self.transition_numbers)} transitions>'
 

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -431,6 +431,34 @@ class NonLTESource:
     _Tex: np.ndarray[float] = field(init=False, repr=False)
 
     @property
+    def Tkin(self: NonLTESource) -> float:
+        return self.mutable_params.Tkin
+
+    @property
+    def collision_density(self: NonLTESource) -> Dict[str, float]:
+        return self.mutable_params.collision_density
+
+    @property
+    def background(self: NonLTESource) -> Union[Continuum, float]:
+        return self.mutable_params.background
+
+    @property
+    def escape_probability(self: NonLTESource) -> EscapeProbability:
+        return self.mutable_params.escape_probability
+
+    @property
+    def column(self: NonLTESource) -> float:
+        return self.mutable_params.column
+
+    @property
+    def dV(self: NonLTESource) -> float:
+        return self.mutable_params.dV
+
+    @property
+    def velocity(self: NonLTESource) -> float:
+        return self.mutable_params.velocity
+
+    @property
     def frequency(self: NonLTESource) -> np.ndarray[float]:
         return self.molecule.radiative_transitions.frequencies * (1.0 - self.velocity / ckm)
 

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 
@@ -107,18 +107,18 @@ class NonLTESource:
 class MaserSimulation:
     """Class for maser simulation"""
 
-    spectrum: Spectrum = None           # Spectrum object associated with this simulation
-    observation: Observation = None     # Observation object associated with this simulation
-    source: List[NonLTESource] = None   # List of NonLTESource objects associated with this simulation
-    continuum: Continuum = None         # Continuum object
-    size: float = 1e3                   # source size
-    ll: List[float] = None              # lower limits [MHz]
-    ul: List[float] = None              # upper limits [MHz]
-    sim_width: float = 10.0             # FWHMs to simulate +/- line center
-    res: float = 0.01                   # resolution if simulating line profiles [MHz]
-    units: str = 'K'                    # units for the simulation; accepts 'K', 'mK', 'Jy/beam'
-    use_obs: bool = False               # flag for line profile simulation to be done with observations
-    aperture: float = None              # aperture size for spectrum extraction [arcsec]
+    spectrum: Optional[Spectrum] = None             # Spectrum object associated with this simulation
+    observation: Optional[Observation] = None       # Observation object associated with this simulation
+    source: Optional[List[NonLTESource]] = None     # List of NonLTESource objects associated with this simulation
+    continuum: Optional[Continuum] = None           # Continuum object
+    size: Optional[float] = 1e3                     # source size
+    ll: Optional[List[float]] = None                # lower limits [MHz]
+    ul: Optional[List[float]] = None                # upper limits [MHz]
+    sim_width: float = 10.0                         # FWHMs to simulate +/- line center
+    res: float = 0.01                               # resolution if simulating line profiles [MHz]
+    units: str = 'K'                                # units for the simulation; accepts 'K', 'mK', 'Jy/beam'
+    use_obs: bool = False                           # flag for line profile simulation to be done with observations
+    aperture: Optional[float] = None                # aperture size for spectrum extraction [arcsec]
 
     def __post_init__(self):
         # set default values

--- a/molsim/radex/classes.py
+++ b/molsim/radex/classes.py
@@ -1,13 +1,17 @@
-from dataclasses import dataclass, field
-from typing import List, Optional
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from functools import lru_cache, partial
+import math
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, TextIO, Tuple, Type, Union
 
 import numpy as np
+from scipy.interpolate import interp1d
 
 from ..classes import Continuum, Observation, Spectrum
 from ..utils import _apply_beam, _apply_aperture
 
 from ..constants import cm, ckm, h, k
-from .interface import run as radex_run, read as radex_read
 
 
 def _planck(T, freq):
@@ -43,6 +47,254 @@ def _intersect_intervals(a, b):
         else:
             j += 1
     return intersected
+
+
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+class Levels:
+    num_levels: int
+    level_numbers: np.ndarray[int]
+    level_energies: np.ndarray[float]
+    statistical_weight: np.ndarray[float]
+    quantum_numbers: np.ndarray[str]
+    level_number_index_map: Dict[int, int]
+
+    def __repr__(self) -> str:
+        return f'<Levels object with {len(self.level_numbers)} levels>'
+
+    @classmethod
+    def from_LAMDA(cls: Type[Levels], file_in: TextIO) -> Levels:
+        fields: Dict[str, Any] = dict()
+
+        _ = file_in.readline()
+        fields['num_levels'] = int(file_in.readline().split(maxsplit=1)[0])
+
+        _ = file_in.readline()
+        fields['level_numbers'] = list()
+        fields['level_energies'] = list()
+        fields['statistical_weight'] = list()
+        fields['quantum_numbers'] = list()
+        for _ in range(fields['num_levels']):
+            cords = file_in.readline().split(maxsplit=4)
+            fields['level_numbers'].append(int(cords[0]))
+            fields['level_energies'].append(float(cords[1]))
+            fields['statistical_weight'].append(float(cords[2]))
+            fields['quantum_numbers'].append(cords[3])
+        fields['level_numbers'] = np.array(fields['level_numbers'])
+        fields['level_energies'] = np.array(fields['level_energies'])
+        fields['statistical_weight'] = np.array(fields['statistical_weight'])
+        fields['quantum_numbers'] = np.array(fields['quantum_numbers'])
+
+        fields['level_number_index_map'] = dict()
+        for index, level_number in enumerate(fields['level_numbers']):
+            fields['level_number_index_map'][level_number] = index
+
+        return cls(**fields)
+
+
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+class RadiativeTransitions:
+    num_transitions: int
+    transition_numbers: np.ndarray[int]
+    upper_level_numbers: np.ndarray[int]
+    lower_level_numbers: np.ndarray[int]
+    spontaneous_decay_rates: np.ndarray[float]
+    upper_level_indices: np.ndarray[int]
+    lower_level_indices: np.ndarray[int]
+
+    def __repr__(self:RadiativeTransitions) -> str:
+        return f'<RadiativeTransitions object with {len(self.transition_numbers)} transitions>'
+
+    @classmethod
+    def from_LAMDA(cls: Type[RadiativeTransitions], file_in: TextIO, levels: Levels) -> RadiativeTransitions:
+        fields: Dict[str, Any] = dict()
+
+        _ = file_in.readline()
+        fields['num_transitions'] = int(file_in.readline().split(maxsplit=1)[0])
+
+        _ = file_in.readline()
+        fields['transition_numbers'] = list()
+        fields['upper_level_numbers'] = list()
+        fields['lower_level_numbers'] = list()
+        fields['spontaneous_decay_rates'] = list()
+        for i in range(fields['num_transitions']):
+            cords = file_in.readline().split(maxsplit=4)
+            fields['transition_numbers'].append(int(cords[0]))
+            fields['upper_level_numbers'].append(int(cords[1]))
+            fields['lower_level_numbers'].append(int(cords[2]))
+            fields['spontaneous_decay_rates'].append(float(cords[3]))
+        fields['transition_numbers'] = np.array(fields['transition_numbers'])
+        fields['upper_level_numbers'] = np.array(fields['upper_level_numbers'])
+        fields['lower_level_numbers'] = np.array(fields['lower_level_numbers'])
+        fields['spontaneous_decay_rates'] = np.array(fields['spontaneous_decay_rates'])
+
+        def level_number_index_map_func(
+            level_number): return levels.level_number_index_map[level_number]
+        fields['upper_level_indices'] = np.array([
+            *map(level_number_index_map_func, fields['upper_level_numbers'])])
+        fields['lower_level_indices'] = np.array([
+            *map(level_number_index_map_func, fields['lower_level_numbers'])])
+
+        return cls(**fields)
+
+
+@dataclass(init=True, repr=False, eq=False, order=False, unsafe_hash=False, frozen=True)
+class CollisionalTransitions:
+    num_temperatures: int
+    num_transitions: int
+    temperatures: np.ndarray[float]
+    transition_numbers: np.ndarray[int]
+    upper_level_numbers: np.ndarray[int]
+    lower_level_numbers: np.ndarray[int]
+    rate_coefficients: np.ndarray[float]
+    upper_level_indices: np.ndarray[int]
+    lower_level_indices: np.ndarray[int]
+
+    def __repr__(self) -> str:
+        return f'<CollisionalTransitions object with {len(self.transition_numbers)} transitions at {len(self.temperatures)} temperatures>'
+
+    @classmethod
+    def from_LAMDA(cls: Type[CollisionalTransitions], file_in: TextIO, levels: Levels) -> CollisionalTransitions:
+        fields: Dict[str, Any] = dict()
+
+        _ = file_in.readline()
+        fields['num_transitions'] = int(file_in.readline().split(maxsplit=1)[0])
+        _ = file_in.readline()
+        fields['num_temperatures'] = int(file_in.readline().split(maxsplit=1)[0])
+
+        _ = file_in.readline()
+        fields['temperatures'] = [*map(float, file_in.readline().split())]
+
+        _ = file_in.readline()
+        fields['transition_numbers'] = list()
+        fields['upper_level_numbers'] = list()
+        fields['lower_level_numbers'] = list()
+        fields['rate_coefficients'] = list()
+        for i in range(fields['num_transitions']):
+            cords = file_in.readline().split()
+            fields['transition_numbers'].append(int(cords[0]))
+            fields['upper_level_numbers'].append(int(cords[1]))
+            fields['lower_level_numbers'].append(int(cords[2]))
+            fields['rate_coefficients'].append([*map(float, cords[3:])])
+        fields['transition_numbers'] = np.array(fields['transition_numbers'])
+        fields['upper_level_numbers'] = np.array(fields['upper_level_numbers'])
+        fields['lower_level_numbers'] = np.array(fields['lower_level_numbers'])
+        fields['rate_coefficients'] = np.array(fields['rate_coefficients'])
+
+        def level_number_index_map_func(level_number):
+            return levels.level_number_index_map[level_number]
+        fields['upper_level_indices'] = np.array([
+            *map(level_number_index_map_func, fields['upper_level_numbers'])])
+        fields['lower_level_indices'] = np.array([
+            *map(level_number_index_map_func, fields['lower_level_numbers'])])
+
+        return cls(**fields)
+
+
+@dataclass(init=True, repr=True, eq=False, order=False, unsafe_hash=False, frozen=True)
+class NonLTEMolecule:
+    name: str
+    weight: float
+    levels: Levels
+    radiative_transitions: RadiativeTransitions
+    collisional_transitions: Dict[str, CollisionalTransitions]
+    partner_name_standardizer: Dict[str, str] = field(init=False, repr=False)
+    collisional_rate_coefficients_getter: Dict[str, Callable[[
+        np.ndarray], np.ndarray]] = field(init=False, repr=False)
+
+    interpolator: InitVar[Union[str, Callable[[np.ndarray,
+                                               np.ndarray], Callable[[float], np.ndarray]]]] = 'slinear'
+
+    def __post_init__(self, interpolator: Union[str, Callable[[np.ndarray, np.ndarray], Callable[[float], np.ndarray]]]) -> None:
+        if isinstance(interpolator, str):
+            interpolator = partial(interp1d, kind=interpolator,
+                                   copy=False, assume_sorted=True)
+        collisional_rate_coefficients_getter: Dict[str, Callable[[float], np.ndarray]] = {
+            partner_name: lru_cache(interpolator(
+                collision_data.temperatures, collision_data.rate_coefficients))
+            for partner_name, collision_data in self.collisional_transitions.items()
+        }
+        object.__setattr__(self, 'collisional_rate_coefficients_getter',
+                           collisional_rate_coefficients_getter)
+
+        partner_name_variants = {
+            'H2':  ['h2'],
+            'pH2': ['ph2', 'p-H2', 'p-h2', 'para-H2', 'para-h2'],
+            'oH2': ['oh2', 'o-H2', 'o-h2', 'ortho-H2', 'ortho-h2'],
+            'e':   ['e-', 'electron', 'electrons'],
+            'H':   ['h'],
+            'He':  ['he'],
+            'H+':  ['h+']
+        }
+        partner_name_standardizer: Dict[str, str] = {
+            variant_name: standard_name
+            for standard_name, variant_names in partner_name_variants.items()
+            for variant_name in variant_names
+        }
+        object.__setattr__(self, 'partner_name_standardizer',
+                           partner_name_standardizer)
+
+    @classmethod
+    def from_LAMDA(cls: Type[NonLTEMolecule], file_in: Union[str, TextIO], **kwargs) -> NonLTEMolecule:
+        fields: Dict[str, Any] = dict(kwargs)
+
+        if isinstance(file_in, str):
+            file_in = open(file_in, 'r')
+
+        """
+        link: https://home.strw.leidenuniv.nl/~moldata/molformat.html
+
+        Format of LAMDA datafiles
+        Below follows a description of the format adopted for presenting the atomic and molecular data in LAMDA. Any similarities with datafiles from other authors is completely coincidental.
+
+        Lines 1 - 2: molecule (or atom) name
+        Lines 3 - 4: molecular (or atomic) weight (a.m.u.)
+        Lines 5 - 6: number of energy levels (NLEV)
+        Lines 7 - 7+NLEV: level number, level energy (cm-1), statistical weight. These numbers may be followed by additional info such as the quantum numbers, which are however not used by the program. The levels must be listed in order of increasing energy.
+        Lines 8+NLEV - 9+NLEV: number of radiative transitions (NLIN)
+        Lines 10+NLEV - 10+NLEV+NLIN: transition number, upper level, lower level, spontaneous decay rate (s-1). These numbers may be followed by additional info such as the line frequency, which is however not used by the program.
+        Lines 11+NLEV+NLIN - 12+NLEV+NLIN: number of collision partners (NPART)
+        This is followed by NPART blocks of collision data:
+        Lines 13+NLEV+NLIN - 14+NLEV+NLIN: collision partner ID and reference. Valid identifications are: 1=H2, 2=para-H2, 3=ortho-H2, 4=electrons, 5=H, 6=He, 7=H+.
+        Lines 15+NLEV+NLIN - 16+NLEV+NLIN: number of transitions for which collisional data exist (NCOL)
+        Lines 17+NLEV+NLIN - 18+NLEV+NLIN: number of temperatures for which collisional data are given
+        Lines 19+NLEV+NLIN - 20+NLEV+NLIN: the NTEMP values of the temperature for which collisional data are given
+        Lines 21+NLEV+NLIN - 21+NLEV+NLIN+NCOL: transition number, upper level, lower level; rate coefficients (cm3s-1) at each temperature.
+        """
+        _ = file_in.readline()
+        fields['name'] = file_in.readline().rstrip()
+
+        _ = file_in.readline()
+        fields['weight'] = float(file_in.readline().split(maxsplit=1)[0])
+
+        fields['levels'] = Levels.from_LAMDA(file_in)
+
+        fields['radiative_transitions'] = RadiativeTransitions.from_LAMDA(
+            file_in, fields['levels'])
+
+        LAMDA_partner_id_name_map = {
+            1: 'H2',
+            2: 'pH2',
+            3: 'oH2',
+            4: 'e',
+            5: 'H',
+            6: 'He',
+            7: 'H+'
+        }
+
+        _ = file_in.readline()
+        num_partners = int(file_in.readline().split(maxsplit=1)[0])
+        fields['collisional_transitions'] = dict()
+        for i in range(num_partners):
+            _ = file_in.readline()
+            partner_id = int(file_in.readline().split(maxsplit=1)[0])
+            if partner_id not in LAMDA_partner_id_name_map:
+                raise ValueError(f'Unregconized collision partner ID: {partner_id = }')
+
+            partner_name = LAMDA_partner_id_name_map[partner_id]
+            fields['collisional_transitions'][partner_name] = CollisionalTransitions.from_LAMDA(
+                file_in, fields['levels'])
+
+        return cls(**fields)
 
 
 @dataclass

--- a/molsim/radex/interface.py
+++ b/molsim/radex/interface.py
@@ -1,0 +1,116 @@
+import numpy as np
+import itertools as it
+import subprocess
+
+def _expand_to_iterable(x):
+    if type(x) is tuple:
+        scale = x[0]
+        low   = x[1]
+        high  = x[2]
+        num   = x[3]
+        if scale == 'linear':
+            return np.linspace(low, high, num=num, endpoint=True)
+        if scale == 'log':
+            return np.geomspace(low, high, num=num, endpoint=True)
+        raise RuntimeError('Unregconized scale: ' + repr(scale))
+    try:
+        return iter(x)
+    except TypeError:
+        return [x]
+
+def run(molfile='hco+.dat', outfile='radex.out', f_low=50, f_high=500, T_k=20.0, n_c={'H2': 1e4}, T_bg=2.73, N=1e13, dV=1.0):
+    inp = []
+    for f_low_, f_high_, T_bg_ in zip(*map(_expand_to_iterable, [f_low, f_high, T_bg])):
+        for T_k_, N_, dV_ in it.product(*map(_expand_to_iterable, [T_k, N, dV])):
+            for n_c_values in it.product(*map(_expand_to_iterable, n_c.values())):
+                tmp = []
+                tmp.append(molfile)
+                tmp.append(outfile)
+                tmp.append('%e %e' % (f_low_, f_high_))
+                tmp.append('%e' % T_k_)
+                tmp.append('%d' % len(n_c))
+                for k, v in zip(n_c.keys(), n_c_values):
+                    tmp.append(k)
+                    tmp.append('%e' % v)
+                tmp.append('%e' % T_bg_)
+                tmp.append('%e' % N_)
+                tmp.append('%e' % dV_)
+                inp.append('\n'.join(tmp))
+    inp = '\n1\n'.join(inp) + '\n0\n'
+    subprocess.run(['radex'], input=inp, stdout=subprocess.DEVNULL, encoding='ascii')
+    return outfile
+
+def read(filename, squeeze=True):
+    parameters_keys = []
+    parameters_values = {}
+    indices, results = [], []
+    with open(filename, 'r') as f:
+        # step = 0    : reading parameters
+        # step = 1, 2 : dumping dummies
+        # step = 3    : reading results
+        step = 0
+        index = []
+        for line in f:
+            if line[0] == '*':
+                if step not in [0, 3]:
+                    raise RuntimeError('Unexpected parameter line')
+                if step == 3:
+                    step = 0
+                    index = []
+                key, value = line.lstrip('*').split(':', 1)
+                key = key.strip()
+                if key == 'T(background)     [K]':
+                    continue
+                value = value.strip()
+                try:
+                    value = float(value)
+                except:
+                    pass
+                if key not in parameters_keys:
+                    parameters_keys.append(key)
+                    parameters_values[key] = []
+                try:
+                    index.append(parameters_values[key].index(value))
+                except ValueError:
+                    index.append(len(parameters_values[key]))
+                    parameters_values[key].append(value)
+            else:
+                if step == 0:
+                    index.append(-1)
+                    if 'LINE' not in parameters_keys:
+                        parameters_keys.append('LINE')
+                        parameters_values['LINE'] = []
+                if step != 3:
+                    step = step + 1
+                    continue
+                l = line.split()
+                transition = ' '.join(l[0:3])
+                try:
+                    index[-1] = parameters_values['LINE'].index(transition)
+                except ValueError:
+                    index[-1] = len(parameters_values['LINE'])
+                    parameters_values['LINE'].append(transition)
+                indices.append(tuple(index))
+                tmp = {}
+                tmp['E_UP']     = float(l[3])
+                tmp['FREQ']     = float(l[4])
+                tmp['WAVEL']    = float(l[5])
+                tmp['T_EX']     = float(l[6])
+                tmp['TAU']      = float(l[7])
+                tmp['T_R']      = float(l[8])
+                tmp['POP_UP']   = float(l[9])
+                tmp['POP_LOW']  = float(l[10])
+                tmp['FLUX_K']   = float(l[11])
+                tmp['FLUX_cgs'] = float(l[12])
+                results.append(tmp)
+    shape = [len(parameters_values[key]) for key in parameters_keys]
+    grid = np.zeros(shape, dtype=object)
+    for index, result in zip(indices, results):
+        grid[index] = result
+    if squeeze:
+        for i, key in list(enumerate(parameters_keys)):
+            if shape[i] == 1:
+                parameters_keys.remove(key)
+                del parameters_values[key]
+        grid = np.squeeze(grid)
+    return parameters_keys, parameters_values, grid

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -21,6 +21,7 @@ class MultiComponentMaserModel(AbstractModel):
     collision_file: str
     observation: Observation
     aperture: float
+    escape_probability: str = 'uniform'
     source_kwargs: Dict[str, Any] = field(default_factory=dict)
 
     _sources: List[NonLTESource] = field(init=False, repr=False, default_factory=list)
@@ -138,7 +139,7 @@ class MultiComponentMaserModel(AbstractModel):
                         Tkin=Tkin,
                         collision_density={'H2': nH2},
                         background=Tbg,
-                        escape_probability=EscapeProbability(type='uniform'),
+                        escape_probability=EscapeProbability(type=self.escape_probability),
                         column=Ncol,
                         dV=dV,
                         velocity=vlsr
@@ -354,7 +355,7 @@ class ChainedMultiComponentMaserModel(MultiComponentMaserModel):
                         Tkin=Tkin,
                         collision_density={'H2': nH2},
                         background=Tbg,
-                        escape_probability=EscapeProbability(type='uniform'),
+                        escape_probability=EscapeProbability(type=self.escape_probability),
                         column=Ncol,
                         dV=dV,
                         velocity=vlsr

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Union, Tuple
 import numpy as np
+import numpy.typing as npt
 from loguru import logger
 from joblib import load
 from scipy.optimize import minimize
@@ -61,33 +62,33 @@ class MultiComponentMaserModel(AbstractModel):
             output += f"{dist}\n"
         return output
 
-    def sample_prior(self) -> np.ndarray:
+    def sample_prior(self) -> npt.NDArray[np.float_]:
         """
         Draw samples from each respective prior distribution to
         return an array of parameters.
 
         Returns
         -------
-        np.ndarray
+        npt.NDArray[np.float_]
             NumPy 1D array of parameter values drawn from the
             respective prior.
         """
         initial = np.array([param.sample() for param in self._distributions])
         return initial
 
-    def simulate_spectrum(self, parameters: np.ndarray) -> np.ndarray:
+    def simulate_spectrum(self, parameters: npt.NDArray[np.float_]) -> npt.NDArray[np.float_]:
         """
         Wraps `molsim` functionality to simulate the spectrum, given a set
         of input parameters as a NumPy 1D array.
 
         Parameters
         ----------
-        parameters : np.ndarray
+        parameters : npt.NDArray[np.float_]
             NumPy 1D array containing parameters for the simulation.
 
         Returns
         -------
-        np.ndarray
+        npt.NDArray[np.float_]
             NumPy 1D array corresponding to the simulated spectrum
         """
         Tbg = parameters[0]
@@ -147,7 +148,7 @@ class MultiComponentMaserModel(AbstractModel):
         return simulated
 
 
-    def prior_constraint(self, parameters: np.ndarray) -> float:
+    def prior_constraint(self, parameters: npt.NDArray[np.float_]) -> float:
         """
         Function that will apply a constrain on the prior. This function
         should be overwritten in child models, say for example in the
@@ -156,7 +157,7 @@ class MultiComponentMaserModel(AbstractModel):
 
         Parameters
         ----------
-        parameters : np.ndarray
+        parameters : npt.NDArray[np.float_]
             NumPy 1D array containing parameter values
 
         Returns
@@ -167,14 +168,14 @@ class MultiComponentMaserModel(AbstractModel):
         """
         return 0.0
 
-    def compute_prior_likelihood(self, parameters: np.ndarray) -> float:
+    def compute_prior_likelihood(self, parameters: npt.NDArray[np.float_]) -> float:
         """
         Calculate the total prior log likelihood. The calculation is handed
         off to the individual distributions.
 
         Parameters
         ----------
-        parameters : np.ndarray
+        parameters : npt.NDArray[np.float_]
             NumPy 1D array containing the model parameters
 
         Returns
@@ -191,14 +192,14 @@ class MultiComponentMaserModel(AbstractModel):
         )
         return lnlikelihood
 
-    def compute_log_likelihood(self, parameters: np.ndarray) -> float:
+    def compute_log_likelihood(self, parameters: npt.NDArray[np.float_]) -> float:
         """
         Calculate the negative log likelihood, given a set of parameters
         and our observed data.
 
         Parameters
         ----------
-        parameters : np.ndarray
+        parameters : npt.NDArray[np.float_]
             [description]
 
         Returns
@@ -212,7 +213,7 @@ class MultiComponentMaserModel(AbstractModel):
         lnlike = - np.log(np.sqrt(2 * np.pi)) * simulation.size - np.sum( np.log(np.fabs(obs.noise)) ) - 0.5 * np.sum( ((obs.Iv - simulation) / obs.noise)**2.0 )
         return lnlike
 
-    def nll(self, parameters: np.ndarray) -> float:
+    def nll(self, parameters: npt.NDArray[np.float_]) -> float:
         """
         Calculate the negative log likelihood. This is functionally exactly
         the sample as `compute_log_likelihood`, except that the sign of the
@@ -220,7 +221,7 @@ class MultiComponentMaserModel(AbstractModel):
 
         Parameters
         ----------
-        parameters : np.ndarray
+        parameters : npt.NDArray[np.float_]
             [description]
 
         Returns
@@ -232,7 +233,7 @@ class MultiComponentMaserModel(AbstractModel):
 
     def mle_optimization(
         self,
-        initial: Union[None, np.ndarray] = None,
+        initial: Union[None, npt.NDArray[np.float_]] = None,
         bounds: Union[None, List[Union[Tuple[float], float]], None] = None,
         **kwargs,
     ):
@@ -248,7 +249,7 @@ class MultiComponentMaserModel(AbstractModel):
 
         Parameters
         ----------
-        initial : Union[None, np.ndarray], optional
+        initial : Union[None, npt.NDArray[np.float_]], optional
             Initial parameters for optimization, by default None, which
             will take the mean of the prior.
         bounds : Union[None, List[Union[Tuple[float, float]]], None], optional

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -1,0 +1,272 @@
+from dataclasses import dataclass
+from typing import List, Union, Tuple
+import numpy as np
+from loguru import logger
+from joblib import load
+from scipy.optimize import minimize
+
+from .classes import NonLTESource, MaserSimulation
+from ..classes import Observation, Continuum
+from ..mcmc.base import AbstractModel, AbstractDistribution, UniformLikelihood, GaussianLikelihood
+from ..utils import load_yaml
+
+@dataclass
+class MultiComponentMaserModel(AbstractModel):
+    Tbg: AbstractDistribution
+    Tks: List[AbstractDistribution]
+    nH2s: List[AbstractDistribution]
+    vlsrs: List[AbstractDistribution]
+    dVs: List[AbstractDistribution]
+    Ncols: List[AbstractDistribution]
+    source_sizes: List[float]
+    continuum: Continuum
+    collision_file: str
+    radex_output: str
+    observation: Observation
+    aperture: float
+
+    def __post_init__(self):
+        # make sure all lists have the same length
+        length = set(map(len, [self.Tks, self.nH2s, self.vlsrs, self.dVs, self.Ncols, self.source_sizes]))
+        self.ncomponent = length.pop()
+        if length:
+            raise ValueError("Distribution lists have inconsistent length.")
+
+        self._distributions = (
+            [self.Tbg] + self.Tks + self.nH2s + self.vlsrs + self.dVs + self.Ncols
+        )
+
+        self.ll = self.observation.spectrum.frequency.min()
+        self.ul = self.observation.spectrum.frequency.max()
+
+    def __len__(self) -> int:
+        return len(self._distributions)
+
+    def _get_components(self):
+        return self._distributions
+
+    def get_names(self) -> List[str]:
+        names = ["Tbg"]
+        for param in ["Tkin", "nH2", "VLSR", "dV", "NCol"]:
+            for i in range(self.ncomponent):
+                names.append(f"{param}_{i}")
+        return names
+
+    def __repr__(self) -> str:
+        output = f"Model: {type(self).__name__}\n"
+        for dist in self._distributions:
+            output += f"{dist}\n"
+        return output
+
+    def sample_prior(self) -> np.ndarray:
+        """
+        Draw samples from each respective prior distribution to
+        return an array of parameters.
+
+        Returns
+        -------
+        np.ndarray
+            NumPy 1D array of parameter values drawn from the
+            respective prior.
+        """
+        initial = np.array([param.sample() for param in self._distributions])
+        return initial
+
+    def simulate_spectrum(self, parameters: np.ndarray) -> np.ndarray:
+        """
+        Wraps `molsim` functionality to simulate the spectrum, given a set
+        of input parameters as a NumPy 1D array.
+
+        Parameters
+        ----------
+        parameters : np.ndarray
+            NumPy 1D array containing parameters for the simulation.
+
+        Returns
+        -------
+        np.ndarray
+            NumPy 1D array corresponding to the simulated spectrum
+        """
+        Tbg = parameters[0]
+        Tkins = parameters[1:1+self.ncomponent]
+        nH2s = parameters[1+self.ncomponent:1+self.ncomponent*2]
+        vlsrs = parameters[1+self.ncomponent*2:1+self.ncomponent*3]
+        dVs = parameters[1+self.ncomponent*3:1+self.ncomponent*4]
+        Ncols = parameters[1+self.ncomponent*4:1+self.ncomponent*5]
+        for i in range(self.ncomponent):
+            if nH2s[i] < 1e3:
+                nH2s[i] = 10 ** nH2s[i]
+            if Ncols[i] < 1e3:
+                Ncols[i] = 10 ** Ncols[i]
+
+        simulated = np.zeros_like(self.observation.spectrum.frequency)
+        for Tkin, nH2, vlsr, dV, Ncol, source_size in zip(Tkins, nH2s, vlsrs, dVs, Ncols, self.source_sizes):
+            source = NonLTESource(
+                velocity=vlsr,
+                dV=dV,
+                column=Ncol,
+                Tbg=Tbg,
+                Tkin=Tkin,
+                collision_density={'H2': nH2},
+                collision_file=self.collision_file,
+                radex_output=self.radex_output
+            )
+            sim = MaserSimulation(
+                observation=self.observation,
+                source=[source],
+                continuum=self.continuum,
+                size=source_size,
+                units='Jy/beam',
+                use_obs=True,
+                aperture=self.aperture
+            )
+            simulated += sim.spectrum.int_profile
+        return simulated
+
+
+    def prior_constraint(self, parameters: np.ndarray) -> float:
+        """
+        Function that will apply a constrain on the prior. This function
+        should be overwritten in child models, say for example in the
+        TMC-1 four component case, where we want to constrain parameter
+        space to certain regions.
+
+        Parameters
+        ----------
+        parameters : np.ndarray
+            NumPy 1D array containing parameter values
+
+        Returns
+        -------
+        float
+            Return zero if parameters pass the constraint, otherwise
+            return -np.inf
+        """
+        return 0.0
+
+    def compute_prior_likelihood(self, parameters: np.ndarray) -> float:
+        """
+        Calculate the total prior log likelihood. The calculation is handed
+        off to the individual distributions.
+
+        Parameters
+        ----------
+        parameters : np.ndarray
+            NumPy 1D array containing the model parameters
+
+        Returns
+        -------
+        float
+            The total prior log likelihood
+        """
+        lnlikelihood = self.prior_constraint(parameters)
+        lnlikelihood += sum(
+            [
+                dist.ln_likelihood(value)
+                for dist, value in zip(self._distributions, parameters)
+            ]
+        )
+        return lnlikelihood
+
+    def compute_log_likelihood(self, parameters: np.ndarray) -> float:
+        """
+        Calculate the negative log likelihood, given a set of parameters
+        and our observed data.
+
+        Parameters
+        ----------
+        parameters : np.ndarray
+            [description]
+
+        Returns
+        -------
+        float
+            Log likelihood of the model
+        """
+        obs = self.observation.spectrum
+        simulation = self.simulate_spectrum(parameters)
+        # match the simulation with the spectrum
+        lnlike = - np.log(np.sqrt(2 * np.pi)) * simulation.size - np.sum( np.log(np.fabs(obs.noise)) ) - 0.5 * np.sum( ((obs.Iv - simulation) / obs.noise)**2.0 )
+        return lnlike
+
+    def nll(self, parameters: np.ndarray) -> float:
+        """
+        Calculate the negative log likelihood. This is functionally exactly
+        the sample as `compute_log_likelihood`, except that the sign of the
+        likelihood is negative for use in maximum likelihood estimation.
+
+        Parameters
+        ----------
+        parameters : np.ndarray
+            [description]
+
+        Returns
+        -------
+        float
+            Negative log likelihood of the model
+        """
+        return -self.compute_log_likelihood(parameters)
+
+    def mle_optimization(
+        self,
+        initial: Union[None, np.ndarray] = None,
+        bounds: Union[None, List[Union[Tuple[float], float]], None] = None,
+        **kwargs,
+    ):
+        """
+        Obtain a maximum likelihood estimate, given an initial starting point in
+        parameter space. Because of the often highly covariant nature of models,
+
+        Additional kwargs are passed into `scipy.optimize.minimize`, and can be
+        used to overwrite things like the optimization method.
+
+        The `Result` object from `scipy.optimize` is returned, which holds the
+        MLE parameters as the attribute `x`, and the likelihood value as `fun`.
+
+        Parameters
+        ----------
+        initial : Union[None, np.ndarray], optional
+            Initial parameters for optimization, by default None, which
+            will take the mean of the prior.
+        bounds : Union[None, List[Union[Tuple[float, float]]], None], optional
+            Bounds for constrained optimization. By default None, which
+            imposes no constraints (highly not recommended!). See the
+            `scipy.optimize.minimize` page for how `bounds` is specified.
+
+        Returns
+        -------
+        `scipy.optimize.Result`
+            A fit `Result` object that contains the final state of the
+            minimization
+        """
+        if initial is None:
+            initial = np.array([self.sample_prior() for _ in range(3000)]).mean(axis=0)
+        opt_kwargs = {
+            "fun": self.nll,
+            "x0": initial,
+            "method": "Powell",
+            "bounds": bounds,
+        }
+        opt_kwargs.update(**kwargs)
+        result = minimize(**opt_kwargs)
+        return result
+
+    @classmethod
+    def from_yml(cls, yml_path: str):
+        input_dict = load_yaml(yml_path)
+        cls_dict = dict()
+        # the two stragglers
+        for key in input_dict.keys():
+            if key not in ["observation", "molecule", "nominal_vlsr"]:
+                if hasattr(input_dict[key], "mu"):
+                    dist = GaussianLikelihood
+                else:
+                    dist = UniformLikelihood
+                cls_dict[key] = dist.from_values(**input_dict[key])
+            else:
+                if key != "nominal_vlsr":
+                    # load in the observed data
+                    cls_dict[key] = load(input_dict[key])
+                else:
+                    logger.warning(f"{key} is not recognized, and therefore ignored.")
+        return cls(**cls_dict)

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -90,10 +90,10 @@ class MultiComponentMaserModel(AbstractModel):
         """
         Tbg = parameters[0]
         Tkins = parameters[1:1+self.ncomponent]
-        nH2s = parameters[1+self.ncomponent:1+self.ncomponent*2]
+        nH2s = np.copy(parameters[1+self.ncomponent:1+self.ncomponent*2])
         vlsrs = parameters[1+self.ncomponent*2:1+self.ncomponent*3]
         dVs = parameters[1+self.ncomponent*3:1+self.ncomponent*4]
-        Ncols = parameters[1+self.ncomponent*4:1+self.ncomponent*5]
+        Ncols = np.copy(parameters[1+self.ncomponent*4:1+self.ncomponent*5])
         for i in range(self.ncomponent):
             if nH2s[i] < 1e3:
                 nH2s[i] = 10 ** nH2s[i]
@@ -141,6 +141,7 @@ class MultiComponentMaserModel(AbstractModel):
                 sim.source[0].mutable_params.dV = dV
                 sim.source[0].mutable_params.velocity = vlsr
                 sim.size = source_size
+                sim._update()
                 simulated += sim.spectrum.int_profile
 
         return simulated

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Union, Tuple
+from typing import Any, Dict, List, Union, Tuple
 import numpy as np
 from loguru import logger
 from joblib import load
@@ -23,6 +23,7 @@ class MultiComponentMaserModel(AbstractModel):
     collision_file: str
     observation: Observation
     aperture: float
+    source_kwargs: Dict[str, Any] = field(default_factory=dict)
 
     _simulations: List[NonLTESimulation] = field(init=False, repr=False, default_factory=list)
 
@@ -115,11 +116,7 @@ class MultiComponentMaserModel(AbstractModel):
                         dV=dV,
                         velocity=vlsr
                     ),
-                    miniter=3,
-                    maxiter=10000,
-                    ccrit=1e-6,
-                    Tex_relaxation_coefficient=1.0,
-                    xpop_relaxation_coefficient=0.6
+                    **self.source_kwargs
                 )
                 sim = NonLTESimulation(
                     observation=self.observation,

--- a/molsim/radex/models.py
+++ b/molsim/radex/models.py
@@ -2,15 +2,11 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Union, Tuple
 import numpy as np
 import numpy.typing as npt
-from loguru import logger
-from joblib import load
 from scipy.optimize import minimize
 
 from .classes import NonLTEMolecule, NonLTESource, NonLTESourceMutableParameters, NonLTESimulation, EscapeProbability
 from ..classes import Observation, Continuum
-from ..mcmc.base import AbstractModel, AbstractDistribution, UniformLikelihood, GaussianLikelihood
-from ..utils import load_yaml
-
+from ..mcmc.base import AbstractModel, AbstractDistribution
 @dataclass
 class MultiComponentMaserModel(AbstractModel):
     Tbg: AbstractDistribution
@@ -274,23 +270,3 @@ class MultiComponentMaserModel(AbstractModel):
         opt_kwargs.update(**kwargs)
         result = minimize(**opt_kwargs)
         return result
-
-    @classmethod
-    def from_yml(cls, yml_path: str):
-        input_dict = load_yaml(yml_path)
-        cls_dict = dict()
-        # the two stragglers
-        for key in input_dict.keys():
-            if key not in ["observation", "molecule", "nominal_vlsr"]:
-                if hasattr(input_dict[key], "mu"):
-                    dist = GaussianLikelihood
-                else:
-                    dist = UniformLikelihood
-                cls_dict[key] = dist.from_values(**input_dict[key])
-            else:
-                if key != "nominal_vlsr":
-                    # load in the observed data
-                    cls_dict[key] = load(input_dict[key])
-                else:
-                    logger.warning(f"{key} is not recognized, and therefore ignored.")
-        return cls(**cls_dict)

--- a/molsim/radex/utils.py
+++ b/molsim/radex/utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class ClosestLRUCache:
+    capacity: int
+    ndim: int
+
+    _keys: np.ndarray[float] = field(init=False, repr=False)
+    _cache: OrderedDict = field(init=False, repr=False)
+
+    def __post_init__(self: ClosestLRUCache):
+        object.__setattr__(self, '_keys', np.empty((self.capacity, self.ndim)))
+        object.__setattr__(self, '_cache', OrderedDict())
+
+    def get(self: ClosestLRUCache, key: np.ndarray[float]) -> Any:
+        size = len(self._cache)
+        if size == 0:
+            return None
+        idx = np.argmin(np.square(self._keys[:size] - key).sum(axis=-1))
+        self._cache.move_to_end(idx)
+        return self._cache[idx]
+
+    def _lru_index(self: ClosestLRUCache):
+        size = len(self._cache)
+        if size < self.capacity:
+            return size
+        return next(iter(self._cache.keys()))
+
+    def put(self: ClosestLRUCache, key: np.ndarray[float], value: Any):
+        idx = self._lru_index()
+        self._keys[idx] = key
+        self._cache[idx] = value
+        self._cache.move_to_end(idx)

--- a/molsim/utils.py
+++ b/molsim/utils.py
@@ -30,7 +30,7 @@ def find_nearest(arr,val):
 		return idx-1
 	else:
 		return idx
-		
+
 def find_nearest_vectorized(arr,val_arr):
     idxs = np.searchsorted(arr, val_arr, side="left")
     for i in range(len(val_arr)):
@@ -41,16 +41,16 @@ def find_nearest_vectorized(arr,val_arr):
 
 def _trim_arr(arr,lls,uls,key_arr=None,return_idxs=False,ll_idxs=None,ul_idxs=None,return_mask=False):
 	'''
-	Trims the input array to the limits specified.  Optionally, will get indices from 
+	Trims the input array to the limits specified.  Optionally, will get indices from
 	the key_arr for trimming instead.
 	'''
-	
+
 	if ll_idxs is not None:
 		return np.concatenate([arr[ll_idx:ul_idx] for ll_idx,ul_idx in zip(ll_idxs,ul_idxs)])
 	# modified to set as False to begin with, and working with
 	# booleans instead of numbers
 	mask_arr = np.zeros_like(arr, dtype=bool)
-	if key_arr is None:	
+	if key_arr is None:
 		for x,y in zip(lls,uls):
 			mask_arr[(arr>x) & (arr<y)] = True
 	else:
@@ -64,7 +64,7 @@ def _trim_arr(arr,lls,uls,key_arr=None,return_idxs=False,ll_idxs=None,ul_idxs=No
 		ll_idxs_out = _find_ones(mask_arr)[0]
 		ul_idxs_out = _find_ones(mask_arr)[1]
 		return arr[mask_arr],ll_idxs_out,ul_idxs_out
-		
+
 @njit
 def _make_gauss(freq0,int0,freq,dV,ckm):
 	return int0*np.exp(-((freq-freq0)**2/(2*((dV*freq0/ckm)/2.35482)**2)))
@@ -75,7 +75,7 @@ def _make_level_dict(qn1low,qn2low,qn3low,qn4low,qn5low,qn6low,qn7low,qn8low,qn1
 
 	#a list to hold levels
 	levels = []
-	
+
 	#we need to sort out unique levels from our catalog.  Those will have unique quantum
 	#numbers. When we find a match to a lower level, add the info in.
 	for x in range(len(frequency)):
@@ -92,12 +92,12 @@ def _make_level_dict(qn1low,qn2low,qn3low,qn4low,qn5low,qn6low,qn7low,qn8low,qn1
 								 'qn7'		:	qn7low[x] if qn7low is not None else None,
 								 'qn8'		:	qn8low[x] if qn8low is not None else None,
 								 'id'		:	qn_list_low[x],
-								 'qnstrfmt'	:	qnstrfmt,			
+								 'qnstrfmt'	:	qnstrfmt,
 								}
-	
+
 	#do it again to fill in energy levels that were upper states and didn't get hit
 	for x in range(len(frequency)):
-		qnstr_up = qn_list_up[x]	
+		qnstr_up = qn_list_up[x]
 		if level_dict[qnstr_up] is None:
 			#calculate the energy.  Move the transition from MHz -> cm-1 -> K
 			freq_cm = (frequency[x]*1E6/ccm)
@@ -114,28 +114,28 @@ def _make_level_dict(qn1low,qn2low,qn3low,qn4low,qn5low,qn6low,qn7low,qn8low,qn1
 									 'qn7'		:	qn7up[x] if qn7up is not None else None,
 									 'qn8'		:	qn8up[x] if qn8up is not None else None,
 									 'id'		:	qn_list_up[x],
-									 'qnstrfmt'	:	qnstrfmt,			
-									}			
-	
-	#go grab the degeneracies	
-	for x in range(len(frequency)):	
-		qnstr_up = qn_list_up[x]	
+									 'qnstrfmt'	:	qnstrfmt,
+									}
+
+	#go grab the degeneracies
+	for x in range(len(frequency)):
+		qnstr_up = qn_list_up[x]
 		if level_dict[qnstr_up]['g'] is None:
 			level_dict[qnstr_up]['g'] = gup[x]
-			
+
 	#now go through and fill any degeneracies that didn't get hit (probably ground states)
 	#assume it's just 2J+1.  Set the flag for a calculated degeneracy to True.
 	for x in level_dict:
 		if level_dict[x]['g'] is None:
-			level_dict[x]['g'] = 2*level_dict[x]['qn1'] + 1	
-			level_dict[x]['g_flag'] = True	
+			level_dict[x]['g'] = 2*level_dict[x]['qn1'] + 1
+			level_dict[x]['g_flag'] = True
 
 	return level_dict
-	
+
 def _make_qnstr(qn1,qn2,qn3,qn4,qn5,qn6,qn7,qn8):
 	qn_list = [qn1,qn2,qn3,qn4,qn5,qn6,qn7,qn8]
 	tmp_list = [str(x).zfill(2) for x in qn_list if x != None]
-	return ''.join(tmp_list)	
+	return ''.join(tmp_list)
 
 def _apply_vlsr(frequency,vlsr):
 	'''
@@ -145,7 +145,7 @@ def _apply_vlsr(frequency,vlsr):
 
 # JIT'd version of the above function; PyMC3 no like Numba
 _njit_apply_vlsr = njit(_apply_vlsr)
-	
+
 def _apply_beam(freq_arr,int_arr,source_size,dish_size,return_beam=False):
 	beam_size = 206265 * 1.22 * (cm/(freq_arr * 1E6)) / dish_size #get beam size in arcsec
 	beam_dilution = source_size**2 / (beam_size**2 + source_size**2)
@@ -154,13 +154,21 @@ def _apply_beam(freq_arr,int_arr,source_size,dish_size,return_beam=False):
 	else:
 		return int_arr*beam_dilution,beam_dilution
 
+def _apply_aperture(int_arr, source_size, aperture_size, return_beam=False):
+	ratio = np.log(2) * (aperture_size / source_size)**2
+	dilution_factor = -np.expm1(-ratio) / ratio
+	if return_beam is False:
+		return int_arr * dilution_factor
+	else:
+		return int_arr * dilution_factor, dilution_factor
+
 def find_limits(freq_arr,spacing_tolerance=100,padding=0):
 	'''
 	Finds the limits of a set of data, including gaps over a width, determined by the
-	spacing tolerance.  Optional padding to each side to allow user to change vlsr and get 
+	spacing tolerance.  Optional padding to each side to allow user to change vlsr and get
 	the simulation within the right area.
 	'''
-	
+
 	# if len(freq_arr) == 0:
 	# 	print('The input array has no data.')
 	# 	return
@@ -183,16 +191,16 @@ def find_limits(freq_arr,spacing_tolerance=100,padding=0):
 	# the following use 1 multiplication per element plus 1 addition and 1 division, i.e. N+2 operations, without allocating temporary array
 	ll *= 1 - padding/ckm
 	ul *= 1 + padding/ckm
-	
+
 	return ll,ul
-	
-def _find_limit_idx(freq_arr,spacing_tolerance=100,padding=25):		
+
+def _find_limit_idx(freq_arr,spacing_tolerance=100,padding=25):
 	'''
-	Finds the indices of the limits of a set of data, including gaps over a width, 
-	determined by the  spacing tolerance.  Adds padding to each side to allow user to 
+	Finds the indices of the limits of a set of data, including gaps over a width,
+	determined by the  spacing tolerance.  Adds padding to each side to allow user to
 	change vlsr and get the simulation within the right area.
 	'''
-	
+
 	if len(freq_arr) == 0:
 		print('The input array has no data.')
 		return
@@ -202,20 +210,20 @@ def _find_limit_idx(freq_arr,spacing_tolerance=100,padding=25):
 	#get the differences
 	diffs = np.diff(freq_arr)
 	spacing = stats.mode(diffs)[0][0]
-	
+
 	gaps = np.where(abs(diffs) > spacing*spacing_tolerance)
-	
+
 	ll = np.concatenate((np.array([freq_arr[0]]),freq_arr[gaps[0][:]+1]))
 	ul = np.concatenate((freq_arr[gaps[0][:]],np.array([freq_arr[-1]])))
-	
+
 	ll -= padding*ll/ckm
 	ul += padding*ul/ckm
-	
+
 	ll = find_nearest_vectorized(freq_arr,ll)
 	ul = find_nearest_vectorized(freq_arr,ul)
-	
+
 	return ll,ul
-	
+
 def _find_nans(arr):
 	'''
 	Find the start,[stop] indices where value is present in arr
@@ -230,12 +238,12 @@ def _find_nans(arr):
 	absdiff = np.abs(np.diff(iszero))
 	# Runs start and end where absdiff is 1.
 	ranges = np.where(absdiff == 1)[0].reshape(-1, 2)
-	
+
 	lls = [x[0] for x in ranges]
 	uls = [x[1] for x in ranges]
-	
-	return lls,uls	
-	
+
+	return lls,uls
+
 def _find_ones(arr):
 	'''
 	Find the start,[stop] indices where value is present in arr
@@ -248,11 +256,11 @@ def _find_ones(arr):
 	absdiff = np.abs(np.diff(iszero))
 	# Runs start and end where absdiff is 1.
 	ranges = np.where(absdiff == 1)[0].reshape(-1, 2)
-	
+
 	lls = [x[0] for x in ranges]
 	uls = [x[1] for x in ranges]
-	
-	return lls,uls		
+
+	return lls,uls
 
 def find_peaks(freq_arr,int_arr,res,min_sep,is_sim=False,sigma=3,kms=True):
 	'''
@@ -272,95 +280,95 @@ def find_peaks(freq_arr,int_arr,res,min_sep,is_sim=False,sigma=3,kms=True):
 		freq_new = freq_arr
 		int_new = int_arr
 		chan_sep = min_sep/res
-	
+
 	indices = signal.find_peaks(int_new,distance=chan_sep)
 
 	if kms is True:
 		indices = [find_nearest(freq_arr,freq_new[x]) for x in indices[0]] #if we had to re-sample things
-		
+
 	if is_sim is True:
 		return np.asarray(indices)
-		
+
 	rms = get_rms(int_arr)
 	indices = [x for x in indices if int_arr[x]>sigma*rms ]
-	
+
 	return np.asarray(indices)
-	
+
 def _get_res(freq_arr):
 	'''
 	Return the resolution of an array (best guess).
 	'''
 	diffs = np.diff(freq_arr)
 	return stats.mode(diffs)[0][0]
-	
-def _make_fmted_qnstr(qns,qnstr_fmt=None):	
+
+def _make_fmted_qnstr(qns,qnstr_fmt=None):
 	'''
 	Given a qnstr_fmt formatter declaration, turns a set of quantum numbers into a
 	human readable output.
-	
+
 	For example, for methanol with some conditions, we want the final output to look like:
-	
+
 	1(1)-A vt=0 for the upper state of the 834.28 transition that has catalog qns of "1 1 - 0," we would use:
-	
+
 	'/#1/(/#2/)/#3[+=+ A,-=- A,= E]/ vt=/#4/'
-	
+
 	'''
-	
+
 	#if a qnstr_fmt is not given, return a nicely cleaned up string
 	if qnstr_fmt is None:
 		qn_bits = [f'{x:>3}' for x in qns]
 		qnstr = ' '
 		return qnstr.join(qn_bits)
-	
+
 	#Clean up the formatting input a bit
 	base_str = qnstr_fmt.split('/')
-	
-	if base_str[0] == '':		
-		del base_str[0]			
+
+	if base_str[0] == '':
+		del base_str[0]
 	if base_str[-1] == '':
 		del base_str[-1]
-	
+
 	#apply the formatting
-	for x in range(len(base_str)):		
+	for x in range(len(base_str)):
 		if '#' in base_str[x] and '[' not in base_str[x]:
 			base_str[x] = base_str[x].replace('#','')
-			idx = int(base_str[x])				
+			idx = int(base_str[x])
 			base_str[x] = str(qns[idx-1])
-			
-		if '#' in base_str[x] and '[' in base_str[x]:		
+
+		if '#' in base_str[x] and '[' in base_str[x]:
 			conditions = base_str[x].split('[')[1].replace(']','').split(',')
-			idx = int(base_str[x].split('[')[0].replace('#',''))			
-			
+			idx = int(base_str[x].split('[')[0].replace('#',''))
+
 			for y in range(len(conditions)):
-				conditions[y] = conditions[y].split('=')	
+				conditions[y] = conditions[y].split('=')
 			value = str(qns[idx-1])
-							
+
 			for y in range(len(conditions)):
 				if conditions[y][0] == value:
-					base_str[x] = str(conditions[y][1])				
-	
-	#make the string and return it				
-	qnstr = ''		
-	return qnstr.join(base_str)	
+					base_str[x] = str(conditions[y][1])
 
-		
+	#make the string and return it
+	qnstr = ''
+	return qnstr.join(base_str)
+
+
 def generate_spcat_qrots(basename,fileout=None,add_temps=None,kmax=150):
 	'''
 	Runs SPCAT in the background and generates a bunch of new partition function data
 	points to be used in a qpart file, which it outputs.  Can be quite slow.
 	'''
-	
+
 	#define all the filenames to be used
 	int_file = f'{basename}.int'
 	int_bak_file = f'{basename}.int.bak'
 	out_file = f'{basename}.out'
 	qpart_file = f'{basename}.qpart'
-	
+
 	#set up a dictionary to hold the temperatures we want partition function values at
 	#fill it with the default set, some new defaults, plus any additional from add_temps
 	q_values = {}
-	default_temps = [1., 3., 5., 7., 9.375, 12., 15., 18.75, 25., 37.5, 45., 55., 65., 
-						75., 95., 115., 135., 150., 175., 200., 225., 250., 275., 300., 
+	default_temps = [1., 3., 5., 7., 9.375, 12., 15., 18.75, 25., 37.5, 45., 55., 65.,
+						75., 95., 115., 135., 150., 175., 200., 225., 250., 275., 300.,
 						400., 500.,
 					]
 	if add_temps is not None:
@@ -368,36 +376,36 @@ def generate_spcat_qrots(basename,fileout=None,add_temps=None,kmax=150):
 			default_temps.append(temp)
 	for temp in default_temps:
 		q_values[temp] = None
-	
+
 	#set up a list of the values SPCAT already calculates so we don't do extra work
 	spcat_defaults = [9.375, 18.75, 37.5, 75., 150., 225., 300.]
-		
+
 	#now we run spcat at each of the temperatures it doesn't already do automatically.
 	#first save a copy of the original int file as backup
 	os.system(f'cp {int_file} {int_bak_file}')
-	
+
 	for temp in default_temps:
-	
+
 		#if its one of spcat's defaults, just move on, we'll get those automatically
 		if temp in spcat_defaults:
 			continue
-	
+
 		#first read in the int file and modify it to a new temperature
 		raw_int = []
-	
+
 		with open(int_file, 'r') as input:
 			for line in input:
 				raw_int.append(line)
-			
+
 		'''
 		an example int file second line looks like this:
 		0  123  3103007   0   150   -10. -10.   40 300
 		we need to modify:
-			the 8th index (the temperature) 
+			the 8th index (the temperature)
 			the 4th index, the max k, to make sure it's high enough for an accurate q
 			the 7th index, max frequency to make sure it's low enough we aren't overloading the computational time
 		'''
-	
+
 		line_split = raw_int[1].split()
 		line_split[4] = f'{kmax}'
 		line_split[7] = '20'
@@ -407,71 +415,71 @@ def generate_spcat_qrots(basename,fileout=None,add_temps=None,kmax=150):
 		with open(int_file, 'w') as output:
 			for line in raw_int:
 				output.write(line)
-				
+
 		#run spcat
 		os.system(f'spcat {int_file}')
-		
+
 		#open the out file and extract the partition function information
 		raw_out = []
-		
+
 		with open(out_file, 'r') as input:
 			for line in input:
 				raw_out.append(line)
-				
+
 		'''
-		The output file is not always formatted the same, depending on how many 
+		The output file is not always formatted the same, depending on how many
 		quantum numbers and such were used.  So we need to look for a key line that says
 		we're getting to the partition functions.  That line is:
-		
+
 		TEMPERATURE - Q(SPIN-ROT.) - log Q(SPIN-ROT.)
-		
+
 		So we'll find that index, then just parse everything in the following lines.
 		Those are of the format
-		
+
 		    300.000   3103007.2692    6.4918
-		    
+
 		Where we want to just split it out and get the 0-index (temperature) and 1-index
-		which is Q.    
-		'''				
-		
+		which is Q.
+		'''
+
 		start_i = 0
-		
+
 		for i in range(len(raw_out)):
 			if 'TEMPERATURE - Q(SPIN-ROT.) - log Q(SPIN-ROT.)' in raw_out[i]:
 				start_i = i+1
-				
+
 		for line in raw_out[start_i:]:
 			temp = float(line.split()[0])
-			qval = float(line.split()[1])			
+			qval = float(line.split()[1])
 			q_values[temp] = qval
-			
+
 	#now we reset the int file back to the original and delete the backup
-	os.system(f'mv {int_bak_file} {int_file}')			
-			
+	os.system(f'mv {int_bak_file} {int_file}')
+
 	#make lists from the dictionary so we can sort them
 	temps_l = list(q_values.keys())
 	temps_l.sort()
 	qvals_l = [q_values[i] for i in temps_l]
-	
+
 	#now we make the output file
 	with open(qpart_file, 'w') as output:
 		output.write('#form : interpolation\n')
 		for t,q in zip(temps_l,qvals_l):
 			output.write(f'{t} {q}\n')
-	
+
 def process_mcmc_json(json_file, molecule, observation, ll=0, ul=float('inf'), line_profile='Gaussian', res=0.0014, stack_params = None, stack_plot_params = None, make_plots=True, return_json = False):
 
 	from molsim.classes import Source, Simulation
 	from molsim.functions import sum_spectra, velocity_stack, matched_filter
 	from molsim.plotting import plot_stack, plot_mf
-	
+
 	with open(json_file) as input:
 		json_dict = json.load(input)
-		
+
 	n_sources = len(json_dict['SourceSize']['mean'])
-	
+
 	sources = []
-	
+
 	for size,vlsr,col,tex,dv in zip(
 		json_dict['SourceSize']['mean'],
 		json_dict['VLSR']['mean'],
@@ -479,16 +487,16 @@ def process_mcmc_json(json_file, molecule, observation, ll=0, ul=float('inf'), l
 		json_dict['Tex']['mean'],
 		json_dict['dV']['mean']):
 		sources.append(Source(size=size,velocity=vlsr,column=col,Tex=tex,dV=dv))
-		
-	sims = [Simulation(mol=molecule,ll=ll,ul=ul,observation=observation,source=x,line_profile=line_profile,res=res) for x in sources]	
+
+	sims = [Simulation(mol=molecule,ll=ll,ul=ul,observation=observation,source=x,line_profile=line_profile,res=res) for x in sources]
 	sum1 = sum_spectra(sims)
-	
+
 	if make_plots is False:
 		if return_json is True:
 			return sources, sims, sum1, json_dict
 		else:
 			return sources, sims, sum1
-			
+
 	internal_stack_params = {'selection' : 'lines',
 					'freq_arr' : observation.spectrum.frequency,
 					'int_arr' : observation.spectrum.Tb,
@@ -504,31 +512,31 @@ def process_mcmc_json(json_file, molecule, observation, ll=0, ul=float('inf'), l
 					'blank_keep_range' : [-5*np.mean([x for x in json_dict['dV']['mean']]),5*np.mean([x for x in json_dict['dV']['mean']])],
 					'flag_lines' : False,
 					'flag_sigma' : 5,
-					}	
-	
+					}
+
 	if stack_params is not None:
 		for x in stack_params:
 			internal_stack_params[x] = stack_params[x]
-		
+
 	stack = velocity_stack(internal_stack_params)
-	
+
 	internal_stack_plot_params = {'xlimits' : [-10,10]}
-	
+
 	if stack_plot_params is not None:
 		for	x in stack_plot_params:
 			internal_stack_plot_params[x] = stack_plot_params[x]
-		
-	plot_stack(stack,params=internal_stack_plot_params)	
-	
+
+	plot_stack(stack,params=internal_stack_plot_params)
+
 	mf = matched_filter(stack.velocity,
 						stack.snr,
 						stack.int_sim[find_nearest(stack.velocity,-2):find_nearest(stack.velocity,2)])
 	plot_mf(mf)
-	
+
 	if return_json is True:
 		return sources, sims, sum1, json_dict
 	else:
-		return sources, sims, sum1	
+		return sources, sims, sum1
 
 
 def read_spcat_out(out_path):
@@ -642,48 +650,3 @@ def parallel_spcat_qrots(basename: str, *more_temps, nproc: int = 4):
             Q = final_dict.get(T)
             write_file.write(f"{float(T):.1f} {Q:.4f}\n")
     print(f"Partition functions written to {basename}.qpart")
-				
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-				
-			


### PR DESCRIPTION
This pull request implements the RADEX non-LTE radiative transfer algorithm in Python. The module utilizes Numba to optimize for the high performance required for MCMC analysis.

This modified non-LTE algorithm supports a continuum temperature being different from the local radiation field temperature, in contrast to RADEX where both temperatures are treated the same and denoted as background temperature. Our expressions reduce back to that of RADEX in the case of a single component when the continuum temperature is equal to the local radiation temperature. Notably, our calculations using this modified non-LTE algorithm reproduce the results returned by RADEX down to machine precision when the results are converged. However, at high molecular column densities, we observed deviations between our results and those from the RADEX algorithm due to RADEX's convergence issues.

This implementation also allows multiple components along the line of sight. The level population of each component is computed independently using the modified non-LTE algorithm within the `NonLTESource` Class. The frequency-dependent optical depth and source function of the i-th component are reconstructed by summing over all lines separately within the `NonLTESimulation` Class.