### PR TITLE
Use github.ref_name for tag_name and release_name

### DIFF
--- a/.github/workflows/change_release.yml
+++ b/.github/workflows/change_release.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
           draft: false

--- a/.github/workflows/change_release.yml
+++ b/.github/workflows/change_release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: ScottBrenner/generate-changelog-action@v1.3.3
 
       - name: Create Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         id: create_release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
Using `github.ref` as the tag name leads to the following error in PR checks during changelog generation:
```
Error: Validation Failed: {"resource":"Release","code":"custom","field":"pre_receive","message":"pre_receive Sorry, branch or tag names starting with 'refs/' are not allowed."}, {"resource":"Release","code":"custom","message":"Published releases must have a valid tag"}
```
In addition, when commits are pushed to the master branch directly,  the format of `github.ref` becomes `refs/heads/<branch_name>` so that using `github.ref` leads to the following error:
```
error: src refspec refs/heads/master matches more than one
```
The reason is that it creates a tag named `refs/heads/master` that points to the current master head, but when master head progresses, the tag still points to the older head and creates ambiguity while resolving for `refs/heads/master`.