### PR TITLE
Fix mutable default values error

### DIFF
--- a/molsim/stack.py
+++ b/molsim/stack.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Tuple, List, Union, Type, Dict
 from functools import lru_cache
 
@@ -121,7 +121,7 @@ class SpectrumChunk:
     _intensity: np.ndarray
     center: np.ndarray
     _weight: float = 1.0
-    _mask: np.ndarray = np.zeros(1, dtype=bool)
+    _mask: np.ndarray = field(default_factory=lambda: np.zeros(1, dtype=bool))
 
     def __post_init__(self):
         # set the default mask to take all values


### PR DESCRIPTION
This commit fixed a pre-existing bug in stack.py that is triggered in python 3.12. When a dataclass has default mutable values, all instances will point to the same mutable container. The commit changed the default values to default_factory.